### PR TITLE
fix branchless_badouel_raytet: bary.x of -Inf value

### DIFF
--- a/src/tettracing.c
+++ b/src/tettracing.c
@@ -868,7 +868,7 @@ float branchless_badouel_raytet(ray *r, raytracer *tracer, mcconfig *cfg, visito
 	faceidx=maskmap[_mm_movemask_ps(_mm_cmpeq_ps(T,_mm_set1_ps(bary.x)))];
 	r->faceid=faceorder[faceidx];
 
-	if(r->faceid>=0){
+	if(r->faceid>=0 && bary.x>=0){
 	    medium *prop;
 	    int *enb, *ee=(int *)(tracer->mesh->elem+eid*tracer->mesh->elemlen);
 	    float mus;


### PR DESCRIPTION
I add a criteria bary.x>=0 at line 871. And actually, you do not this criteria again at line 934 https://github.com/fangq/mmc/blob/7ab48d431260c1827df37fd8cabdd19cf5cd7ce9/src/tettracing.c#L934. This is why I change that part in the previous pull request. Thanks!