### PR TITLE
don't pass LFLAGS when building for Octave

### DIFF
--- a/commons/Makefile_common.mk
+++ b/commons/Makefile_common.mk
@@ -126,7 +126,7 @@ mexsse:         BINARY=mmc_sse
 oct:            BINARY=mmc.mex
 octsse:         BINARY=mmc_sse.mex
 oct octsse:     ARFLAGS+=--mex mmclab.cpp -I$(INCLUDEDIR)
-oct octsse:     AR=CC=$(CC) CXX=$(CXX) LFLAGS='$(OPENMP)' LDFLAGS='$(LFLAGS)' CPPFLAGS='$(CCFLAGS) $(USERCCFLAGS) -std=c++11' $(USEROCTOPT) $(MKOCT)
+oct octsse:     AR=CC=$(CC) CXX=$(CXX) LDFLAGS='$(LFLAGS)' CPPFLAGS='$(CCFLAGS) $(USERCCFLAGS) -std=c++11' $(USEROCTOPT) $(MKOCT)
 oct octsse:     USERARFLAGS=-o $(BINDIR)/mmc
 
 TARGETSUFFIX:=$(suffix $(BINARY))


### PR DESCRIPTION
The `LFLAGS` variable shouldn't be overridden, and `$(OPENMP)` is already present in `$(CCFLAGS)`. This allows building when the Octave libraries are not in a standard link search directory. Works for me for several different versions of Octave.

Fixes #18.