### PR TITLE
fix wrong usage of free() on pointer returned by mxGetPr

### DIFF
--- a/src/mmc_host.c
+++ b/src/mmc_host.c
@@ -262,6 +262,10 @@ printf("thread num=%d\n",threadnum);
 	}
 	#pragma omp barrier
 	visitor_clear(&visit);
+	if(visit.partialpath)
+	    free(visit.partialpath);
+	if(cfg->issaveseed && visit.photonseed)
+	    free(visit.photonseed);
 }
         if(seeds) free(seeds);
 
@@ -304,6 +308,9 @@ printf("thread num=%d\n",threadnum);
 			mesh_getdetimage(detimage,master.partialpath,master.bufpos,cfg,mesh);
 			mesh_savedetimage(detimage,cfg);	free(detimage);
 		}
+		free(master.partialpath);
+                if(cfg->issaveseed && master.photonseed)
+		    free(master.photonseed);
 	}
         MMCDEBUG(cfg,dlTime,(cfg->flog,"\tdone\t%d\n",GetTimeMillis()-t0));
         visitor_clear(&master);

--- a/src/mmclab.cpp
+++ b/src/mmclab.cpp
@@ -302,6 +302,10 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
             }
             #pragma omp barrier
 	    visitor_clear(&visit);
+	    if(visit.partialpath)
+	        free(visit.partialpath);
+            if(cfg.issaveseed && visit.photonseed)
+	        free(visit.photonseed);
 	}
 }
 
@@ -382,7 +386,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
       mexPrintf("Unknown Exception");
     }
 
-    /** \subsection sclean End the simulation */
+    /** \subsection sclean End the simulation */   
     visitor_clear(&master);
     mesh_clear(&mesh);
     mcx_clearcfg(&cfg);

--- a/src/tettracing.c
+++ b/src/tettracing.c
@@ -1689,12 +1689,4 @@ void visitor_clear(visitor* visit){
 	visit->kahanc0=NULL;
 	free(visit->kahanc1);
 	visit->kahanc1=NULL;
-	if(visit->photonseed){
-		free(visit->photonseed);
-		visit->photonseed=NULL;
-	}
-	if(visit->partialpath){
-		free(visit->partialpath);
-		visit->partialpath=NULL;
-	}
 }


### PR DESCRIPTION
I note that previously, master.partialpath and master.photonseed have never been freed in mmclab.cpp. By looking at this part of the code, https://github.com/fangq/mmc/blob/389d8520669c6e061caa69727c85cde91dc92ae1/src/mmclab.cpp#L270-L290
 I realize that in the 'demo_example_replay.m', cfg.issaveexit=1 and apparently nlhs>=2, therefore master.partialpath and master.photonseed are NOT allocated using either 'calloc' or 'malloc' BUT using mcGetPr, which I believe can not be freed using free().