### PR TITLE
enable photon detection inside elements next to zero-labeled element

### DIFF
--- a/src/mmc_core.cl
+++ b/src/mmc_core.cl
@@ -1292,7 +1292,7 @@ __device__ void onephoton(unsigned int id,__local float *ppath, __constant MCXPa
 		    }
 #ifdef MCX_SAVE_DETECTORS
 if(GPU_PARAM(gcfg,issavedet)){
-		    if(r.eid<0){
+		    if(r.eid<=0){
 #ifdef MCX_SAVE_SEED
                        if(GPU_PARAM(gcfg,isextdet) && type[oldeid-1]==GPU_PARAM(gcfg,maxmedia)+1)
                           savedetphoton(n_det,detectedphoton,ppath,&(r.p0),&(r.vec),gmed,oldeid,gcfg,photonseed,initseed);


### PR DESCRIPTION
This commit is to address the issue reported under this thread: https://groups.google.com/g/mmc-users/c/PIjWUG8Hyb0