### PR TITLE
update tend to ensure that tend - tstart is multiple of tstep

### DIFF
--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -1957,6 +1957,7 @@ void mcx_validatecfg(mcconfig *cfg){
      if(cfg->tend<=cfg->tstart)
          MMC_ERROR(-2,"field 'tend' must be greater than field 'tstart'");
      cfg->maxgate=(int)((cfg->tend-cfg->tstart)/cfg->tstep+0.5);
+     cfg->tend=cfg->tstart+cfg->tstep*cfg->maxgate;
 
      if(cfg->srctype==stPattern && cfg->srcpattern==NULL)
         MMC_ERROR(-2,"the 'srcpattern' field can not be empty when your 'srctype' is 'pattern'");

--- a/src/mmclab.cpp
+++ b/src/mmclab.cpp
@@ -723,6 +723,7 @@ void mmc_validate_config(mcconfig *cfg, tetmesh *mesh){
      if(cfg->tend<=cfg->tstart)
          MEXERROR("field 'tend' must be greater than field 'tstart'");
      cfg->maxgate=(int)((cfg->tend-cfg->tstart)/cfg->tstep+0.5);
+     cfg->tend=cfg->tstart+cfg->tstep*cfg->maxgate;
 
      if(mesh->prop==0)
         MEXERROR("you must define the 'prop' field in the input structure");


### PR DESCRIPTION
In https://github.com/fangq/mmc/blob/1e915a6b6bd7b169b40ab4d3ef7955a5426ecf0f/src/tettracing.c#L984, if 
`cfg->tend > (cfg.tstep * cfg->maxgate)`
r->Lmove could be larger than it is supposed to be, resulting in out of bound photon position and therefore invalid memory access when saving output to grid.