### PR TITLE
Fixed wrong face orientation for fimmc

### DIFF
--- a/mmclab/example/demo_immc_basic.m
+++ b/mmclab/example/demo_immc_basic.m
@@ -114,6 +114,8 @@ end
 % sum(allfaces>4,2)==3 gives the triangles that are made of nodes 5/6/7/8
 cfg.faceroi=reshape(double(sum(allfaces>4,2)==3), size(cfg.elem,1),size(facelist,1));
 cfg.faceroi(cfg.faceroi>0)=0.1;
+cfg.faceroi(3,1)=-4;
+cfg.faceroi(5,1)=-6;
 
 % run node-based iMMC
 flux_fimmc=mmclab(cfg);

--- a/src/tettracing.c
+++ b/src/tettracing.c
@@ -1147,10 +1147,11 @@ float ray_face_intersect(ray *r, raytracer *tracer, int *ee, int faceid, int bas
 	vec_mult(&r->vec,r->Lmove,&ptemp);
 	vec_add(&r->p0,&ptemp,&ptemp);		// P1: ptemp
 
-	pf1 = tracer->mesh->node[ee[nc[ifaceorder[faceid]][0]]-1];	// any point on face
-    	fnorm.x=(&(tracer->n[baseid].x))[faceid];		// normal vector of the face
-	fnorm.y=(&(tracer->n[baseid].x))[faceid+4];
-	fnorm.z=(&(tracer->n[baseid].x))[faceid+8];
+	int ncindex = ifaceorder[faceid];
+	pf1 = tracer->mesh->node[ee[nc[ncindex][0]]-1];	// any point on face
+    	fnorm.x=(&(tracer->n[baseid].x))[ncindex];		// normal vector of the face
+	fnorm.y=(&(tracer->n[baseid].x))[ncindex+4];
+	fnorm.z=(&(tracer->n[baseid].x))[ncindex+8];
 
 	vec_diff(&pf0,&pf1,&pv);
 	distf0 = vec_dot(&pv,&fnorm);
@@ -2285,11 +2286,11 @@ void init_face_inout(ray *r, raytracer *tracer){
         vec_mult(&r->vec,r->Lmove,&ptemp);
         vec_add(&r->p0,&ptemp,&ptemp);		// P1
 
-        pf1 = tracer->mesh->node[ee[nc[ifaceorder[index]][0]]-1];	// any point on face
-        fnorm.x=(&(tracer->n[baseid].x))[index];		// normal vector of the face
-        fnorm.y=(&(tracer->n[baseid].x))[index+4];
-        fnorm.z=(&(tracer->n[baseid].x))[index+8];
-
+	int ncindex = ifaceorder[index];
+        pf1 = tracer->mesh->node[ee[nc[ncindex][1]]-1];	// any point on face
+        fnorm.x=(&(tracer->n[baseid].x))[ncindex];		// normal vector of the face
+        fnorm.y=(&(tracer->n[baseid].x))[ncindex+4];
+        fnorm.z=(&(tracer->n[baseid].x))[ncindex+8];
         vec_diff(&pf0,&pf1,&pv);
         distf0 = vec_dot(&pv,&fnorm);
 


### PR DESCRIPTION
ifaceorder should also be added while getting the norm for the labeled face in fimmc. Reference elements for fimmc were also added in demo_immc_basic.m