### PR TITLE
Support photon sharing on the GPU, fix #86

### DIFF
--- a/mmclab/example/demo_photon_sharing.m
+++ b/mmclab/example/demo_photon_sharing.m
@@ -16,7 +16,7 @@ cfg.prop = [0 0 1 1; 0.01 10 0.9 1.37];
 cfg.tstart = 0;
 cfg.tend = 5e-9;
 cfg.tstep = 1e-10;
-cfg.gpuid = -1;
+cfg.gpuid = 1;
 cfg.method = 'elem';
 cfg.debuglevel = 'TP';
 
@@ -30,7 +30,7 @@ pat(11:30, 11:30, 4) = 1; % pattern with bright square in the middle
 pat(16:25, :, 5) = 1;
 pat(:, 16:25, 5) = 1;     % pattern with a bright cross
 
-cfg.srcpattern = pat;
+cfg.srcpattern = permute(pat, [3 1 2]);
 
 %% run the simulation
 

--- a/mmclab/mmc2json.m
+++ b/mmclab/mmc2json.m
@@ -13,9 +13,6 @@ function varargout = mmc2json(cfg, filestub, varargin)
 %         mcxpreview supports the cfg input for both mcxlab and mmclab.
 %    filestub: the filestub is the name stub for all output files,including
 %         filestub.json: the JSON input file
-%         filestub_vol.bin: the volume file if cfg.vol is defined
-%         filestub_shapes.json: the domain shape file if cfg.shapes is defined
-%         filestub_pattern.bin: the domain shape file if cfg.pattern is defined
 %
 %         if filestub ends with '.json', then mmc2json saves the mesh data
 %         in the single-file mode, and the mesh information is stored
@@ -58,16 +55,7 @@ if (isfield(cfg, 'detpos') && ~isempty(cfg.detpos))
     end
 end
 if (isfield(cfg, 'srcpattern') && ~isempty(cfg.srcpattern))
-    Optode.Source.Pattern.Nx = size(cfg.srcpattern, 1);
-    Optode.Source.Pattern.Ny = size(cfg.srcpattern, 2);
-    Optode.Source.Pattern.Nz = size(cfg.srcpattern, 3);
-    Optode.Source.Pattern.Data = single(cfg.srcpattern);
-    if (~singlefile)
-        Optode.Source.Pattern.Data = [filestub '_pattern.bin'];
-        fid = fopen(Optode.Source.Pattern.Data, 'wb');
-        fwrite(fid, cfg.srcpattern, 'float32');
-        fclose(fid);
-    end
+    Optode.Source.Pattern = single(cfg.srcpattern);
 end
 
 %% define the domain and optical properties

--- a/mmclab/mmclab.m
+++ b/mmclab/mmclab.m
@@ -105,8 +105,8 @@ function varargout = mmclab(varargin)
 %                                by srcpos, srcpos+srcparam1(1:3) and srcpos+srcparam2(1:3)
 %                      'pattern' - a 3D quadrilateral pattern illumination, same as above, except
 %                                srcparam1(4) and srcparam2(4) specify the pattern array x/y dimensions,
-%                                and srcpattern is a floating-point pattern array, with values between [0-1].
-%                                if cfg.srcnum>1, srcpattern must be a floating-point array with
+%                                and srcpattern is a double-precision pattern array, with values between [0-1].
+%                                if cfg.srcnum>1, srcpattern must be a 3-D double-precision array with
 %                                a dimension of [srcnum srcparam1(4) srcparam2(4)]
 %                                Example: <demo_photon_sharing.m>
 %                      'fourier' - spatial frequency domain source, similar to 'planar', except

--- a/src/mmc_cl_host.c
+++ b/src/mmc_cl_host.c
@@ -92,8 +92,8 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
     cl_mem* gweight, *gdref, *gdetphoton, *gseed, *genergy, *greporter, *gdebugdata;     /*read-write buffers*/
     cl_mem* gprogress = NULL, *gdetected = NULL, *gphotonseed = NULL; /*write-only buffers*/
 
-    cl_uint meshlen = ((cfg->method == rtBLBadouelGrid) ? cfg->crop0.z : mesh->ne) * cfg->srcnum;
-    cfg->crop0.w = meshlen * cfg->maxgate; // offset for the second buffer
+    cl_uint meshlen = ((cfg->method == rtBLBadouelGrid) ? cfg->crop0.z : mesh->ne) * cfg->srcnum;    /**< total output data length in float count per time-frame */
+    cfg->crop0.w = meshlen * cfg->maxgate;    /**< total output data length, before double-buffer expansion */
 
     cl_float*  field, *dref = NULL;
 
@@ -107,6 +107,7 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
 
     GPUInfo* gpu = NULL;
     float4* propdet;
+    double energytot = 0.0, energyesc = 0.0;
 
     MCXParam param = {{{cfg->srcpos.x, cfg->srcpos.y, cfg->srcpos.z}}, {{cfg->srcdir.x, cfg->srcdir.y, cfg->srcdir.z}},
         cfg->tstart, cfg->tend, (uint)cfg->isreflect, (uint)cfg->issavedet, (uint)cfg->issaveexit,
@@ -124,7 +125,7 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
         mesh->nn, mesh->ne, mesh->nf, {{mesh->nmin.x, mesh->nmin.y, mesh->nmin.z}}, cfg->nout,
         cfg->roulettesize, cfg->srcnum, {{cfg->crop0.x, cfg->crop0.y, cfg->crop0.z, cfg->crop0.w}},
         mesh->srcelemlen, {{cfg->bary0.x, cfg->bary0.y, cfg->bary0.z, cfg->bary0.w}},
-        cfg->e0, cfg->isextdet, meshlen, (mesh->prop + 1 + cfg->isextdet) + cfg->detnum,
+        cfg->e0, cfg->isextdet, (meshlen / cfg->srcnum), (mesh->prop + 1 + cfg->isextdet) + cfg->detnum,
         (MIN((MAX_PROP - param.maxpropdet), ((mesh->ne) << 2)) >> 2), /*max count of elem normal data in const mem*/
         cfg->issaveseed, cfg->seed, cfg->maxjumpdebug
     };
@@ -145,6 +146,8 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
     }
 
     param.reclen = sharedmemsize / sizeof(float);
+
+    sharedmemsize += sizeof(cl_float) * (cfg->srcnum << 1);   /**< store energyesc/energytot */
 
     if (cfg->srctype == stPattern && cfg->srcnum > 1) {
         sharedmemsize += sizeof(cl_float) * cfg->srcnum;
@@ -256,7 +259,7 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
         Pphotonseed = (RandType*)calloc(cfg->maxdetphoton, (sizeof(RandType) * RAND_BUF_LEN));
     }
 
-    fieldlen = meshlen * cfg->maxgate;
+    fieldlen = cfg->crop0.w;  /**< total float counts of the output buffer, before double-buffer expansion (x2) for improving saving accuracy */
 
     if (cfg->seed > 0) {
         srand(cfg->seed);
@@ -310,7 +313,7 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
         OCL_ASSERT(((gparam[i] = clCreateBuffer(mcxcontext, RO_MEM, sizeof(MCXParam), &param, &status), status)));
 
         Pseed = (cl_uint*)malloc(sizeof(cl_uint) * gpu[i].autothread * RAND_SEED_WORD_LEN);
-        energy = (cl_float*)calloc(sizeof(cl_float), gpu[i].autothread << 1);
+        energy = (cl_float*)calloc(sizeof(cl_float) * cfg->srcnum, gpu[i].autothread << 1);
 
         for (j = 0; j < gpu[i].autothread * RAND_SEED_WORD_LEN; j++) {
             Pseed[j] = rand();
@@ -331,7 +334,7 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
             OCL_ASSERT(((gdebugdata[i] = clCreateBuffer(mcxcontext, RW_MEM, sizeof(float) * (debuglen * cfg->maxjumpdebug), cfg->exportdebugdata, &status), status)));
         }
 
-        OCL_ASSERT(((genergy[i] = clCreateBuffer(mcxcontext, RW_MEM, sizeof(float) * (gpu[i].autothread << 1), energy, &status), status)));
+        OCL_ASSERT(((genergy[i] = clCreateBuffer(mcxcontext, RW_MEM, sizeof(float) * (gpu[i].autothread << 1) * cfg->srcnum, energy, &status), status)));
         OCL_ASSERT(((gdetected[i] = clCreateBuffer(mcxcontext, RW_MEM, sizeof(cl_uint), &detected, &status), status)));
         OCL_ASSERT(((greporter[i] = clCreateBuffer(mcxcontext, RW_MEM, sizeof(MCXReporter), &reporter, &status), status)));
 
@@ -509,6 +512,8 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
         MMC_FPRINTF(cfg->flog, "- [device %d(%d): %s] threadph=%d oddphotons=%d np=%.1f nthread=%d nblock=%d repetition=%d\n", i, gpu[i].id, gpu[i].name, threadphoton, oddphotons,
                     cfg->nphoton * cfg->workload[i] / fullload, (int)gpu[i].autothread, (int)gpu[i].autoblock, cfg->respin);
 
+        MMC_FPRINTF(cfg->flog, "requesting %d bytes of shared memory\n", sharedmemsize * (int)gpu[i].autoblock);
+
         OCL_ASSERT(((mcxkernel[i] = clCreateKernel(mcxprogram, "mmc_main_loop", &status), status)));
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 0, sizeof(cl_uint), (void*)&threadphoton)));
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 1, sizeof(cl_uint), (void*)&oddphotons)));
@@ -556,8 +561,10 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
         cfg->exportdebugdata = (float*)calloc(sizeof(float), (debuglen * cfg->maxjumpdebug));
     }
 
-    cfg->energytot = 0.f;
-    cfg->energyesc = 0.f;
+    cfg->energytot = (double*)calloc(cfg->srcnum, sizeof(double));
+    cfg->energyesc = (double*)calloc(cfg->srcnum, sizeof(double));
+    energytot = 0.0;
+    energyesc = 0.0;
     cfg->runtime = 0;
 
     //simulate for all time-gates in maxgate groups per run
@@ -636,13 +643,17 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
                 reporter.raytet += rep.raytet;
                 reporter.jumpdebug += rep.jumpdebug;
 
-                energy = (cl_float*)calloc(sizeof(cl_float), gpu[devid].autothread << 1);
-                OCL_ASSERT((clEnqueueReadBuffer(mcxqueue[devid], genergy[devid], CL_TRUE, 0, sizeof(cl_float) * (gpu[devid].autothread << 1),
+                energy = (cl_float*)calloc(sizeof(cl_float) * cfg->srcnum, gpu[devid].autothread << 1);
+                OCL_ASSERT((clEnqueueReadBuffer(mcxqueue[devid], genergy[devid], CL_TRUE, 0, sizeof(cl_float) * (gpu[devid].autothread << 1) * cfg->srcnum,
                                                 energy, 0, NULL, NULL)));
 
                 for (i = 0; i < gpu[devid].autothread; i++) {
-                    cfg->energyesc += energy[(i << 1)];
-                    cfg->energytot += energy[(i << 1) + 1];
+                    for (j = 0; j < cfg->srcnum; j++) {
+                        cfg->energyesc[j] += energy[(i << 1) * cfg->srcnum + j];
+                        cfg->energytot[j] += energy[((i << 1) + 1) * cfg->srcnum + j];
+                        energyesc += energy[(i << 1) * cfg->srcnum + j];
+                        energytot += energy[((i << 1) + 1) * cfg->srcnum + j];
+                    }
                 }
 
                 free(energy);
@@ -707,6 +718,7 @@ is more than what your have specified (%d), please use the -H option to specify 
                     OCL_ASSERT((clEnqueueReadBuffer(mcxqueue[devid], gdref[devid], CL_TRUE, 0, sizeof(float)*nflen,
                                                     rawdref, 0, NULL, NULL)));
 
+                    //TODO: saving dref has not yet adopting double-buffer
                     for (i = 0; i < nflen; i++) { //accumulate field, can be done in the GPU
                         dref[i] += rawdref[i];    //+rawfield[i+fieldlen];
                     }
@@ -724,7 +736,7 @@ is more than what your have specified (%d), please use the -H option to specify 
                     mcx_fflush(cfg->flog);
 
                     for (i = 0; i < fieldlen; i++) { //accumulate field, can be done in the GPU
-                        field[i] += rawfield[i] + rawfield[i + fieldlen];    //+rawfield[i+fieldlen];
+                        field[i] += rawfield[i] + rawfield[i + fieldlen];
                     }
 
                     free(rawfield);
@@ -754,15 +766,20 @@ is more than what your have specified (%d), please use the -H option to specify 
                 cfg->exportfield[i] += field[i];
             }
         } else {
-            for (i = 0; i < cfg->maxgate; i++)
-                for (j = 0; j < mesh->ne; j++) {
-                    float ww = field[i * mesh->ne + j] * 0.25f;
-                    int k;
+            int srcid;
 
-                    for (k = 0; k < mesh->elemlen; k++) {
-                        cfg->exportfield[i * mesh->nn + mesh->elem[j * mesh->elemlen + k] - 1] += ww;
+            for (i = 0; i < cfg->maxgate; i++) {
+                for (j = 0; j < mesh->ne; j++) {
+                    for (srcid = 0; srcid < cfg->srcnum; srcid++) {
+                        float ww = field[(i * mesh->ne + j) * cfg->srcnum + srcid] * 0.25f;
+                        int k;
+
+                        for (k = 0; k < mesh->elemlen; k++) {
+                            cfg->exportfield[(i * mesh->nn + mesh->elem[j * mesh->elemlen + k] - 1) * cfg->srcnum + srcid] += ww;
+                        }
                     }
                 }
+            }
         }
     }
 
@@ -773,11 +790,17 @@ is more than what your have specified (%d), please use the -H option to specify 
     }
 
     if (cfg->isnormalized) {
-        MMC_FPRINTF(cfg->flog, "normalizing raw data ...\t");
-        mcx_fflush(cfg->flog);
+        double cur_normalizer, sum_normalizer = 0.0, energyabs = 0.0;
 
-        cfg->energyabs = cfg->energytot - cfg->energyesc;
-        mesh_normalize(mesh, cfg, cfg->energyabs, cfg->energytot, 0);
+        for (j = 0; j < cfg->srcnum; j++) {
+            energyabs =  cfg->energytot[j] - cfg->energyesc[j];
+            cur_normalizer = mesh_normalize(mesh, cfg, energyabs, cfg->energytot[j], j);
+            sum_normalizer += cur_normalizer;
+            MMCDEBUG(cfg, dlTime, (cfg->flog, "source %d\ttotal simulated energy: %f\tabsorbed: "S_BOLD""S_BLUE"%5.5f%%"S_RESET"\tnormalizor=%g\n",
+                                   j + 1, cfg->energytot[j], 100.f * energyabs / cfg->energytot[j], cur_normalizer));
+        }
+
+        cfg->his.normalizer = sum_normalizer / cfg->srcnum; // average normalizer value for all simulated sources
     }
 
 #ifndef MCX_CONTAINER
@@ -817,7 +840,7 @@ is more than what your have specified (%d), please use the -H option to specify 
     MMC_FPRINTF(cfg->flog, "simulated %zu photons (%zu) with %d devices (ray-tet %.0f)\nMCX simulation speed: %.2f photon/ms\n",
                 cfg->nphoton, cfg->nphoton, workdev, reporter.raytet, (double)cfg->nphoton / toc);
     MMC_FPRINTF(cfg->flog, "total simulated energy: %.2f\tabsorbed: %5.5f%%\n(loss due to initial specular reflection is excluded in the total)\n",
-                cfg->energytot, (cfg->energytot - cfg->energyesc) / cfg->energytot * 100.f);
+                energytot, (energytot - energyesc) / energytot * 100.f);
     mcx_fflush(cfg->flog);
 
     OCL_ASSERT(clReleaseMemObject(gprogress[0]));
@@ -899,6 +922,10 @@ is more than what your have specified (%d), please use the -H option to specify 
     free(mcxkernel);
 
     free(waittoread);
+    free(cfg->energytot);
+    free(cfg->energyesc);
+    cfg->energytot = NULL;
+    cfg->energyesc = NULL;
 
     if (gpu) {
         free(gpu);

--- a/src/mmc_cl_host.c
+++ b/src/mmc_cl_host.c
@@ -513,7 +513,7 @@ void mmc_run_cl(mcconfig* cfg, tetmesh* mesh, raytracer* tracer) {
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 0, sizeof(cl_uint), (void*)&threadphoton)));
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 1, sizeof(cl_uint), (void*)&oddphotons)));
         //OCL_ASSERT((clSetKernelArg(mcxkernel[i], 2, sizeof(cl_mem), (void*)(gparam+i))));
-        OCL_ASSERT((clSetKernelArg(mcxkernel[i], 3, sharedmemsize * (int)gpu[i].autothread, NULL)));
+        OCL_ASSERT((clSetKernelArg(mcxkernel[i], 3, sharedmemsize * (int)gpu[i].autoblock, NULL)));
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 4, sizeof(cl_mem), (void*)(gproperty + i))));
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 5, sizeof(cl_mem), (void*)(gnode + i))));
         OCL_ASSERT((clSetKernelArg(mcxkernel[i], 6, sizeof(cl_mem), (void*)(gelem + i))));

--- a/src/mmc_cl_host.h
+++ b/src/mmc_cl_host.h
@@ -96,7 +96,6 @@ typedef struct PRE_ALIGN(32) GPU_mcconfig {
     cl_int    e0;
     cl_int    isextdet;
     cl_int    framelen;
-    cl_uint   nbuffer;
     cl_uint   maxpropdet;
     cl_uint   normbuf;
     cl_int    issaveseed;

--- a/src/mmc_core.cl
+++ b/src/mmc_core.cl
@@ -506,7 +506,7 @@ __device__ uint finddetector(float3* p0, __constant float4* gmed, __constant MCX
 __device__ void savedetphoton(__global float* n_det, __global uint* detectedphoton,
                               __local float* ppath, ray* r, __constant Medium* gmed,
                               int extdetid, __constant MCXParam* gcfg, __global RandType* photonseed, RandType* initseed) {
-    uint detid = (extdetid < 0) ? finddetector(p0, (__constant float4*)gmed, gcfg) : extdetid;
+    uint detid = (extdetid < 0) ? finddetector(&(r->p0), (__constant float4*)gmed, gcfg) : extdetid;
 
     if (detid) {
         uint baseaddr = atomic_inc(detectedphoton);
@@ -535,9 +535,9 @@ __device__ void savedetphoton(__global float* n_det, __global uint* detectedphot
                 n_det[baseaddr++] = r->p0.x;
                 n_det[baseaddr++] = r->p0.y;
                 n_det[baseaddr++] = r->p0.z;
-                n_det[baseaddr++] = r->v.x;
-                n_det[baseaddr++] = r->v.y;
-                n_det[baseaddr++] = r->v.z;
+                n_det[baseaddr++] = r->vec.x;
+                n_det[baseaddr++] = r->vec.y;
+                n_det[baseaddr++] = r->vec.z;
             }
 
             n_det[baseaddr++] = ppath[GPU_PARAM(gcfg, reclen) - 1]; // save partial pathlength to the memory

--- a/src/mmc_core.cl
+++ b/src/mmc_core.cl
@@ -901,7 +901,7 @@ __device__ float branchless_badouel_raytet(ray* r, __constant MCXParam* gcfg, __
                                 float oldval = atomicadd(weight + newidx * GPU_PARAM(gcfg, srcnum) + pidx, r->oldweight * ppath[GPU_PARAM(gcfg, reclen) + pidx]);
 
                                 if (oldval > MAX_ACCUM) {
-                                if (atomicadd(weight + newidx * GPU_PARAM(gcfg, srcnum) + pidx, -oldval) < 0.0f) {
+                                    if (atomicadd(weight + newidx * GPU_PARAM(gcfg, srcnum) + pidx, -oldval) < 0.0f) {
                                         atomicadd(weight + newidx * GPU_PARAM(gcfg, srcnum) + pidx, oldval);
                                     } else {
                                         atomicadd(weight + newidx * GPU_PARAM(gcfg, srcnum) + pidx + gcfg->crop0.w, oldval);

--- a/src/mmc_core.cl
+++ b/src/mmc_core.cl
@@ -47,6 +47,9 @@ inline __device__ __host__ int get_global_id(int idx) {
 inline __device__ __host__ int get_local_id(int idx) {
     return (idx == 0) ? threadIdx.x : ( (idx == 1) ? threadIdx.y : threadIdx.z );
 }
+inline __device__ __host__ int get_local_size(int idx) {
+    return (idx == 0) ? blockDim.x : ( (idx == 1) ? blockDim.y : blockDim.z );
+}
 inline __device__ __host__ float3 operator *(float3 a, float3 b) {
     return make_float3(a.x * b.x, a.y * b.y, a.z * b.z);
 }
@@ -480,7 +483,6 @@ __device__ inline float atomicadd(volatile __global float* address, const float 
 
 #endif
 
-#ifdef MCX_SAVE_DETECTORS
 __device__ void clearpath(__local float* p, int len) {
     uint i;
 
@@ -489,6 +491,7 @@ __device__ void clearpath(__local float* p, int len) {
     }
 }
 
+#ifdef MCX_SAVE_DETECTORS
 __device__ uint finddetector(float3* p0, __constant float4* gmed, __constant MCXParam* gcfg) {
     uint i;
 
@@ -1443,7 +1446,7 @@ __device__ void launchnewphoton(__constant MCXParam* gcfg, ray* r, __global floa
 
 __device__ void onephoton(unsigned int id, __local float* ppath, __constant MCXParam* gcfg, __global float3* node, __global int* elem, __global float* weight, __global float* dref,
                           __global int* type, __global int* facenb,  __global int* srcelem, __global float4* normal, __constant Medium* gmed,
-                          __global float* n_det, __global uint* detectedphoton, float* energytot, float* energyesc, __private RandType* ran, int* raytet, __global float* srcpattern,
+                          __global float* n_det, __global uint* detectedphoton, __local float* energytot, __local float* energyesc, __private RandType* ran, int* raytet, __global float* srcpattern,
                           __global float* replayweight, __global float* replaytime, __global RandType* photonseed, __global MCXReporter* reporter, __global float* gdebugdata) {
 
     int oldeid, fixcount = 0;
@@ -1464,12 +1467,10 @@ __device__ void onephoton(unsigned int id, __local float* ppath, __constant MCXP
 
     /*initialize the photon parameters*/
     launchnewphoton(gcfg, &r, node, elem, srcelem, ran, srcpattern);
-    *energytot += r.weight;
+
 #ifdef MCX_SAVE_DETECTORS
 
     if (GPU_PARAM(gcfg, issavedet)) {
-        clearpath(ppath, GPU_PARAM(gcfg, reclen));  /*clear shared memory for saving history of a new photon*/
-
         if (GPU_PARAM(gcfg, srctype) != stPattern || GPU_PARAM(gcfg, srcnum) == 1) {
             ppath[GPU_PARAM(gcfg, reclen) - 1] = r.weight; /*last record in partialpath is the initial photon weight*/
         } else if (GPU_PARAM(gcfg, srctype) == stPattern) {
@@ -1479,9 +1480,12 @@ __device__ void onephoton(unsigned int id, __local float* ppath, __constant MCXP
 
 #endif
 
-    if (GPU_PARAM(gcfg, srctype) == stPattern && GPU_PARAM(gcfg, srcnum) > 1) {
-        for (oldeid = 0; oldeid > GPU_PARAM(gcfg, srcnum); oldeid++) {
+    if (GPU_PARAM(gcfg, srcnum) == 1) {
+        *energytot += r.weight;
+    } else {
+        for (oldeid = 0; oldeid < GPU_PARAM(gcfg, srcnum); oldeid++) {
             ppath[GPU_PARAM(gcfg, reclen) + oldeid] = srcpattern[r.posidx * GPU_PARAM(gcfg, srcnum) + oldeid];
+            energytot[oldeid] += r.weight * ppath[GPU_PARAM(gcfg, reclen) + oldeid];
         }
     }
 
@@ -1700,7 +1704,9 @@ __device__ void onephoton(unsigned int id, __local float* ppath, __constant MCXP
         savedebugdata(&r, id, reporter, gdebugdata, gcfg);
     }
 
-    *energyesc += r.weight;
+    for (oldeid = 0; oldeid < GPU_PARAM(gcfg, srcnum); oldeid++) {
+        energyesc[oldeid] += r.weight * ppath[GPU_PARAM(gcfg, reclen) + oldeid];
+    }
 }
 
 __kernel void mmc_main_loop(const int nphoton, const int ophoton,
@@ -1714,7 +1720,6 @@ __kernel void mmc_main_loop(const int nphoton, const int ophoton,
 
     RandType t[RAND_BUF_LEN];
     int idx = get_global_id(0);
-    float  energyesc = 0.f, energytot = 0.f;
     int raytet = 0;
 
 #ifdef __NVCC__
@@ -1725,6 +1730,9 @@ __kernel void mmc_main_loop(const int nphoton, const int ophoton,
         gpu_rng_init(t, n_seed, idx);
     }
 
+    clearpath(sharedmem, get_local_size(0) * ((GPU_PARAM(gcfg, srcnum) << 1) +
+              (GPU_PARAM(gcfg, reclen) + (GPU_PARAM(gcfg, srcnum) > 1) * GPU_PARAM(gcfg, srcnum))));
+
     /*launch photons*/
     for (int i = 0; i < nphoton + (idx < ophoton); i++) {
         if (GPU_PARAM(gcfg, seed) == SEED_FROM_FILE)
@@ -1732,14 +1740,17 @@ __kernel void mmc_main_loop(const int nphoton, const int ophoton,
                 t[j] = replayseed[(idx * nphoton + MIN(idx, ophoton) + i) * RAND_BUF_LEN + j];
             }
 
-        onephoton(idx * nphoton + MIN(idx, ophoton) + i, sharedmem + get_local_id(0) *
-                  (GPU_PARAM(gcfg, reclen) + (GPU_PARAM(gcfg, srcnum) > 1) * GPU_PARAM(gcfg, srcnum)), gcfg, node, elem,
-                  weight, dref, type, facenb, srcelem, normal, gmed, n_det, detectedphoton, &energytot, &energyesc, t, &raytet,
+        onephoton(idx * nphoton + MIN(idx, ophoton) + i, sharedmem + get_local_size(0) * (GPU_PARAM(gcfg, srcnum) << 1) +
+                  get_local_id(0) * (GPU_PARAM(gcfg, reclen) + (GPU_PARAM(gcfg, srcnum) > 1) * GPU_PARAM(gcfg, srcnum)), gcfg, node, elem,
+                  weight, dref, type, facenb, srcelem, normal, gmed, n_det, detectedphoton, sharedmem + get_local_id(0) * GPU_PARAM(gcfg, srcnum),
+                  sharedmem + (get_local_size(0) + get_local_id(0)) * GPU_PARAM(gcfg, srcnum), t, &raytet,
                   srcpattern, replayweight, replaytime, photonseed, reporter, gdebugdata);
     }
 
-    energy[idx << 1] = energyesc;
-    energy[1 + (idx << 1)] = energytot;
+    for (int i = 0; i < GPU_PARAM(gcfg, srcnum); i++) {
+        energy[(idx << 1) * GPU_PARAM(gcfg, srcnum) + i] += sharedmem[(get_local_size(0) + get_local_id(0)) * GPU_PARAM(gcfg, srcnum) + i];
+        energy[((idx << 1) + 1) * GPU_PARAM(gcfg, srcnum) + i] += sharedmem[get_local_id(0) * GPU_PARAM(gcfg, srcnum) + i];
+    }
 
     if (GPU_PARAM(gcfg, debuglevel) & MCX_DEBUG_PROGRESS && progress) {
         atomic_inc(progress);

--- a/src/mmc_cu_host.cu
+++ b/src/mmc_cu_host.cu
@@ -300,6 +300,8 @@ void mmc_run_simulation(mcconfig* cfg, tetmesh* mesh, raytracer* tracer, GPUInfo
         sharedmemsize += sizeof(float) * cfg->srcnum;
     }
 
+    gpuid = cfg->deviceid[threadid] - 1;
+
     sharedmemsize *= ((int)gpu[gpuid].autoblock);
 
 #ifdef _OPENMP
@@ -309,8 +311,6 @@ void mmc_run_simulation(mcconfig* cfg, tetmesh* mesh, raytracer* tracer, GPUInfo
     if (threadid < MAX_DEVICE && cfg->deviceid[threadid] == '\0') {
         return;
     }
-
-    gpuid = cfg->deviceid[threadid] - 1;
 
     if (gpuid < 0) {
         mcx_error(-1, "GPU ID must be non-zero", __FILE__, __LINE__);

--- a/src/mmc_raytrace.c
+++ b/src/mmc_raytrace.c
@@ -386,12 +386,11 @@ float plucker_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visitor* visit) {
                     #pragma omp atomic
                     tracer->mesh->weight[eid + tshift] += ww;
                 } else if (cfg->srctype == stPattern) { // must be pattern and srcnum more than 1
-                    int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w; // total number of pixels in each pattern
                     int pidx; // pattern index
 
                     for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                         #pragma omp atomic
-                        tracer->mesh->weight[(eid + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[pidx * psize + r->posidx];
+                        tracer->mesh->weight[(eid + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                     }
                 }
             }
@@ -437,13 +436,12 @@ float plucker_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visitor* visit) {
                                 tracer->mesh->weight[ee[i] - 1 + tshift] += ww * (baryp0[i] + baryout[i]);
                             }
                         } else if (cfg->srctype == stPattern) { // must be pattern and srcnum more than 1
-                            int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w; // total number of pixels in each pattern
                             int pidx; // pattern index
 
                             for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                 for (i = 0; i < 4; i++) {
                                     #pragma omp atomic
-                                    tracer->mesh->weight[(ee[i] - 1 + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[pidx * psize + r->posidx] * (baryp0[i] + baryout[i]);
+                                    tracer->mesh->weight[(ee[i] - 1 + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[r->posidx * cfg->srcnum + pidx] * (baryp0[i] + baryout[i]);
                                 }
                             }
                         }
@@ -716,12 +714,11 @@ float havel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visitor* visit) {
                         #pragma omp atomic
                         tracer->mesh->weight[eid + tshift] += ww;
                     } else if (cfg->srctype == stPattern) { // must be pattern and srcnum more than 1
-                        int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w; // total number of pixels in each pattern
                         int pidx; // pattern index
 
                         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                             #pragma omp atomic
-                            tracer->mesh->weight[(eid + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[pidx * psize + r->posidx];
+                            tracer->mesh->weight[(eid + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                         }
                     }
                 } else {
@@ -734,13 +731,12 @@ float havel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visitor* visit) {
                             tracer->mesh->weight[ee[j] - 1 + tshift] += barypout[j];
                         }
                     } else if (cfg->srctype == stPattern) {
-                        int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w; // total number of pixels in each pattern
                         int pidx; // pattern index
 
                         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                             for (j = 0; j < 4; j++) {
                                 #pragma omp atomic
-                                tracer->mesh->weight[(ee[j] - 1 + tshift)*cfg->srcnum + pidx] += barypout[j] * cfg->srcpattern[pidx * psize + r->posidx];
+                                tracer->mesh->weight[(ee[j] - 1 + tshift)*cfg->srcnum + pidx] += barypout[j] * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                             }
                         }
                     }
@@ -1405,7 +1401,6 @@ float branchless_badouel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visito
         medium* prop;
         int* enb, *ee = (int*)(tracer->mesh->elem + eid * tracer->mesh->elemlen);
         float mus;
-        int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w; // total number of pixels in each pattern
         int pidx; // pattern index
 
         if (cfg->implicit == 1 && r->inroi && tracer->mesh->edgeroi && fabs(tracer->mesh->edgeroi[eid * 6]) < EPS) {
@@ -1526,7 +1521,7 @@ float branchless_badouel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visito
                             } else if (cfg->srctype == stPattern) {
                                 for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                     #pragma omp atomic
-                                    tracer->mesh->weight[r->oldidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[pidx * psize + r->posidx];
+                                    tracer->mesh->weight[r->oldidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                                 }
                             }
 
@@ -1543,7 +1538,7 @@ float branchless_badouel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visito
                             } else if (cfg->srctype == stPattern) {
                                 for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                     #pragma omp atomic
-                                    tracer->mesh->weight[newidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[pidx * psize + r->posidx];
+                                    tracer->mesh->weight[newidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                                 }
                             }
 
@@ -1577,7 +1572,7 @@ float branchless_badouel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visito
                                     for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                             #pragma omp atomic
-                                            tracer->mesh->weight[r->oldidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[pidx * psize + r->posidx];
+                                            tracer->mesh->weight[r->oldidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                                         }
                                     }
                                 }
@@ -1596,7 +1591,7 @@ float branchless_badouel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visito
                                     for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                                             #pragma omp atomic
-                                            tracer->mesh->weight[newidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[pidx * psize + r->posidx];
+                                            tracer->mesh->weight[newidx * cfg->srcnum + pidx] += r->oldweight * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                                         }
                                     }
                                 }
@@ -1621,7 +1616,7 @@ float branchless_badouel_raytet(ray* r, raytracer* tracer, mcconfig* cfg, visito
                         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
                             for (i = 0; i < 3; i++) {
                                 #pragma omp atomic
-                                tracer->mesh->weight[(ee[out[faceidx][i]] - 1 + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[pidx * psize + r->posidx];
+                                tracer->mesh->weight[(ee[out[faceidx][i]] - 1 + tshift)*cfg->srcnum + pidx] += ww * cfg->srcpattern[r->posidx * cfg->srcnum + pidx];
                             }
                         }
                     }
@@ -1761,13 +1756,11 @@ void onephoton(size_t id, raytracer* tracer, tetmesh* mesh, mcconfig* cfg,
     } else if (cfg->srctype == stPattern) {
         *((int*)(r.partialpath + visit->reclen - 2)) = r.posidx;
 
-        int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w;
-
         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
             if (cfg->seed == SEED_FROM_FILE && (cfg->outputtype == otWL || cfg->outputtype == otWP)) {
                 kahany = cfg->replayweight[r.photonid] - visit->kahanc0[pidx];    /* when replay mode, accumulate detected photon weight */
             } else {
-                kahany = r.weight * cfg->srcpattern[pidx * psize + r.posidx] - visit->kahanc0[pidx];
+                kahany = r.weight * cfg->srcpattern[r.posidx * cfg->srcnum + pidx] - visit->kahanc0[pidx];
             }
 
             kahant = visit->launchweight[pidx] + kahany;
@@ -2033,10 +2026,8 @@ void onephoton(size_t id, raytracer* tracer, tetmesh* mesh, mcconfig* cfg,
         visit->kahanc1[0] = (kahant - visit->absorbweight[0]) - kahany;
         visit->absorbweight[0] = kahant;
     } else if (cfg->srctype == stPattern) {
-        int psize = (int)cfg->srcparam1.w * (int)cfg->srcparam2.w;
-
         for (pidx = 0; pidx < cfg->srcnum; pidx++) {
-            kahany = r.Eabsorb * cfg->srcpattern[pidx * psize + r.posidx] - visit->kahanc1[pidx];
+            kahany = r.Eabsorb * cfg->srcpattern[r.posidx * cfg->srcnum + pidx] - visit->kahanc1[pidx];
             kahant = visit->absorbweight[pidx] + kahany;
             visit->kahanc1[pidx] = (kahant - visit->absorbweight[pidx]) - kahany;
             visit->absorbweight[pidx] = kahant;

--- a/src/mmc_utils.c
+++ b/src/mmc_utils.c
@@ -326,7 +326,6 @@ void mcx_initcfg(mcconfig* cfg) {
     cfg->energyesc = 0.f;
     cfg->runtime = 0;
     cfg->autopilot = 1;
-    cfg->nbuffer = 0;
     cfg->gpuid = 0;
     cfg->maxjumpdebug = 10000000;
     cfg->exportdebugdata = NULL;
@@ -3216,8 +3215,6 @@ void mcx_parsecmd(int argc, char* argv[], mcconfig* cfg) {
                         i = mcx_readarg(argc, argv, i, &(cfg->debugphoton), "int");
                     } else if (strcmp(argv[i] + 2, "maxjumpdebug") == 0) {
                         i = mcx_readarg(argc, argv, i, &(cfg->maxjumpdebug), "int");
-                    } else if (strcmp(argv[i] + 2, "buffer") == 0) {
-                        i = mcx_readarg(argc, argv, i, &(cfg->nbuffer), "int");
                     } else if (strcmp(argv[i] + 2, "gridsize") == 0) {
                         i = mcx_readarg(argc, argv, i, &(cfg->steps.x), "float");
                         cfg->steps.y = cfg->steps.x;

--- a/src/mmc_utils.c
+++ b/src/mmc_utils.c
@@ -321,9 +321,8 @@ void mcx_initcfg(mcconfig* cfg) {
     cfg->exportdetected = NULL;
     cfg->exportseed = NULL;
     cfg->detectedcount = 0;
-    cfg->energytot = 0.f;
-    cfg->energyabs = 0.f;
-    cfg->energyesc = 0.f;
+    cfg->energytot = NULL;
+    cfg->energyesc = NULL;
     cfg->runtime = 0;
     cfg->autopilot = 1;
     cfg->gpuid = 0;
@@ -419,6 +418,14 @@ void mcx_clearcfg(mcconfig* cfg) {
 
     if (cfg->roidata) {
         free(cfg->roidata);
+    }
+
+    if (cfg->energytot) {
+        free(cfg->energytot);
+    }
+
+    if (cfg->energyesc) {
+        free(cfg->energyesc);
     }
 
 #ifndef MCX_EMBED_CL
@@ -1582,6 +1589,8 @@ int mcx_loadjson(cJSON* root, mcconfig* cfg) {
                     if (ndim == 3 && dims[2] > 1 && dims[0] > 1 && cfg->srctype == MCX_SRC_PATTERN) {
                         cfg->srcnum = dims[0];
                     }
+
+                    mcx_convertrow2col(cfg->srcpattern, (uint3*)dims);
                 } else {
                     int nx = FIND_JSON_KEY("Nx", "Optode.Source.Pattern.Nx", subitem, 0, valueint);
                     int ny = FIND_JSON_KEY("Ny", "Optode.Source.Pattern.Ny", subitem, 0, valueint);
@@ -2776,6 +2785,35 @@ int mcx_isbinstr(const char* str) {
     return 1;
 }
 
+/**
+ * @brief Convert a row-major (C/C++) array to a column-major (MATLAB/FORTRAN) array
+ *
+ * @param[in,out] vol: a 3D array (wrapped in 1D) to be converted
+ * @param[in] dim: the dimensions of the 3D array
+ */
+
+void  mcx_convertrow2col(float* vol, uint3* dim) {
+    uint x, y, z;
+    unsigned int dimxy, dimyz;
+    float* newvol = NULL;
+
+    if (vol == NULL || dim->x == 0 || dim->y == 0 || dim->z == 0) {
+        return;
+    }
+
+    newvol = (float*)malloc(sizeof(float) * dim->x * dim->y * dim->z);
+    dimxy = dim->x * dim->y;
+    dimyz = dim->y * dim->z;
+
+    for (x = 0; x < dim->x; x++)
+        for (y = 0; y < dim->y; y++)
+            for (z = 0; z < dim->z; z++) {
+                newvol[z * dimxy + y * dim->x + x] = vol[x * dimyz + y * dim->z + z];
+            }
+
+    memcpy(vol, newvol, sizeof(float) * dim->x * dim->y * dim->z);
+    free(newvol);
+}
 
 /**
  * @brief Validate all input fields, and warn incompatible inputs

--- a/src/mmc_utils.c
+++ b/src/mmc_utils.c
@@ -2847,10 +2847,6 @@ void mcx_validatecfg(mcconfig* cfg) {
         MMC_ERROR(-2, "Implicit MMC is currently only supported in the CPU, please set -G -1 or cfg.gpuid=-1");
     }
 
-    if (cfg->srcnum > 1 && (int)(cfg->gpuid) >= 0) {
-        MMC_ERROR(-2, "Photon-sharing MMC is currently only supported in the CPU, please set -G -1 or cfg.gpuid=-1");
-    }
-
     for (i = 0; i < MAX_DEVICE; i++)
         if (cfg->deviceid[i] == '0') {
             cfg->deviceid[i] = '\0';

--- a/src/mmc_utils.h
+++ b/src/mmc_utils.h
@@ -281,7 +281,6 @@ typedef struct MMC_config {
     unsigned int runtime;          /**<total simulation runtime in ms*/
     char autopilot;                /**<1 optimal setting for dedicated card, 2, for non dedicated card*/
     float normalizer;              /**<normalization factor*/
-    unsigned int nbuffer;          /**<2^nbuffer is the number of buffers for accummulation*/
     unsigned int gpuid;            /**<positive integer denotes the 1st/2nd/... OpenCL or CUDA devices, 0xFFFFFFFF for CPU only*/
     int compute;                   /**<0: sse, 1: opencl or 2: cuda*/
     char isdumpjson;               /**<1 to save json */

--- a/src/mmc_utils.h
+++ b/src/mmc_utils.h
@@ -276,7 +276,8 @@ typedef struct MMC_config {
     unsigned char* exportseed;     /*memory buffer when returning the RNG seed to matlab*/
     float* exportdetected;         /*memory buffer when returning the partial length info to external programs such as matlab*/
     float* exportdebugdata;        /**<pointer to the buffer where the photon trajectory data are stored*/
-    double energytot, energyabs, energyesc;
+    double* energytot;             /**<total energy launched for each source, a buffer of length srcnum */
+    double* energyesc;             /**<total energy escaped for each source, a buffer of length srcnum */
     unsigned int detectedcount;    /**<total number of detected photons*/
     unsigned int runtime;          /**<total simulation runtime in ms*/
     char autopilot;                /**<1 optimal setting for dedicated card, 2, for non dedicated card*/
@@ -333,6 +334,7 @@ void mcx_convertcol2row4d(unsigned int** vol, uint4* dim);
 void mcx_savejdata(char* filename, mcconfig* cfg);
 int  mcx_jdataencode(void* vol,  int ndim, uint* dims, char* type, int byte, int zipid, void* obj, int isubj, int iscol, mcconfig* cfg);
 int  mcx_jdatadecode(void** vol, int* ndim, uint* dims, int maxdim, char** type, cJSON* obj, mcconfig* cfg);
+void mcx_convertrow2col(float* vol, uint3* dim);
 void mcx_savejnii(OutputType* vol, int ndim, uint* dims, float* voxelsize, char* name, int isfloat, int iscol, mcconfig* cfg);
 void mcx_savebnii(OutputType* vol, int ndim, uint* dims, float* voxelsize, char* name, int isfloat, int iscol, mcconfig* cfg);
 void mcx_savejdet(float* ppath, void* seeds, uint count, int doappend, mcconfig* cfg);

--- a/src/mmclab.cpp
+++ b/src/mmclab.cpp
@@ -443,7 +443,6 @@ void mmc_set_field(const mxArray* root, const mxArray* item, int idx, mcconfig* 
     const dimtype* arraydim;
     char* jsonshapes = NULL;
     int i, j;
-    dimtype k;
 
     if (strcmp(name, "nphoton") == 0 && cfg->photonseed != NULL) {
         return;
@@ -778,25 +777,26 @@ void mmc_set_field(const mxArray* root, const mxArray* item, int idx, mcconfig* 
         printf("mmc.session='%s';\n", cfg->session);
     } else if (strcmp(name, "srcpattern") == 0) {
         arraydim = mxGetDimensions(item);
+        dimtype dimz = 1;
+
+        if (mxGetNumberOfDimensions(item) == 3) {
+            dimz = arraydim[2];
+            cfg->srcnum = arraydim[0];
+        }
+
         double* val = mxGetPr(item);
 
         if (cfg->srcpattern) {
             free(cfg->srcpattern);
         }
 
-        if (mxGetNumberOfDimensions(item) == 3) {
-            cfg->srcnum = arraydim[2];
-        } else {
-            cfg->srcnum = 1;
+        cfg->srcpattern = (float*)malloc(arraydim[0] * arraydim[1] * dimz * sizeof(float));
+
+        for (i = 0; i < arraydim[0]*arraydim[1]*dimz; i++) {
+            cfg->srcpattern[i] = val[i];
         }
 
-        cfg->srcpattern = (float*)malloc(arraydim[0] * arraydim[1] * cfg->srcnum * sizeof(float));
-
-        for (k = 0; k < arraydim[0]*arraydim[1]*cfg->srcnum; k++) {
-            cfg->srcpattern[k] = val[k];
-        }
-
-        printf("mmc.srcpattern=[%d %d %d];\n", (int)arraydim[0], (int)arraydim[1], cfg->srcnum);
+        printf("mmc.srcpattern=[%ld %ld %ld];\n", arraydim[0], arraydim[1], dimz);
     } else if (strcmp(name, "method") == 0) {
         int len = mxGetNumberOfElements(item);
         const char* methods[] = {"plucker", "havel", "badouel", "elem", "grid", ""};

--- a/src/mmclab.cpp
+++ b/src/mmclab.cpp
@@ -777,7 +777,7 @@ void mmc_set_field(const mxArray* root, const mxArray* item, int idx, mcconfig* 
         printf("mmc.session='%s';\n", cfg->session);
     } else if (strcmp(name, "srcpattern") == 0) {
         arraydim = mxGetDimensions(item);
-        dimtype dimz = 1;
+        dimtype dimz = 1, k;
 
         if (mxGetNumberOfDimensions(item) == 3) {
             dimz = arraydim[2];
@@ -792,8 +792,8 @@ void mmc_set_field(const mxArray* root, const mxArray* item, int idx, mcconfig* 
 
         cfg->srcpattern = (float*)malloc(arraydim[0] * arraydim[1] * dimz * sizeof(float));
 
-        for (i = 0; i < arraydim[0]*arraydim[1]*dimz; i++) {
-            cfg->srcpattern[i] = val[i];
+        for (k = 0; k < arraydim[0]*arraydim[1]*dimz; k++) {
+            cfg->srcpattern[k] = val[k];
         }
 
         printf("mmc.srcpattern=[%ld %ld %ld];\n", arraydim[0], arraydim[1], dimz);


### PR DESCRIPTION
A break-change has been made to the photon-sharing simulations:

previously, the mmc photon sharing requires a 3D cfg->srcpattern array with the 3rd dimension being the pattern dimension; to make it consistent with MCX photon-sharing, in the implementation of GPU based photon-sharing, we now use the 1st dimension as the pattern dimension.