### PR TITLE
Expose integer isspecular and isextdet in pMMC

### DIFF
--- a/src/pmmc.cpp
+++ b/src/pmmc.cpp
@@ -127,9 +127,10 @@ void parse_config(const py::dict& user_cfg, mcconfig& mcx_config, tetmesh& mesh)
     GET_SCALAR_FIELD(user_cfg, mcx_config, tstep, py::float_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, tend, py::float_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, isreflect, py::int_);
-    GET_SCALAR_FIELD(user_cfg, mcx_config, isspecular, py::bool_);
+    GET_SCALAR_FIELD(user_cfg, mcx_config, isspecular, py::int_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, ismomentum, py::bool_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, issaveexit, py::bool_);
+    GET_SCALAR_FIELD(user_cfg, mcx_config, isextdet, py::bool_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, issave2pt, py::bool_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, issavedet, py::int_);
     GET_SCALAR_FIELD(user_cfg, mcx_config, issaveseed, py::bool_);


### PR DESCRIPTION
This PR improves pMMC configuration parity with the MMC core/MMCLAB for two existing configuration fields.

Changes:

* Parse `cfg.isspecular` as an integer in pMMC instead of a boolean.
* Expose `cfg.isextdet` through the pMMC Python config parser.

Rationale:

The MMC core already supports integer-valued `isspecular` modes, including code paths that check for `isspecular == 2`. MMCLAB passes this scalar configuration value through without casting it to boolean, but pMMC currently parses it as a boolean, preventing Python users from selecting the full set of supported modes.

The core also uses `isextdet` for external wide-field detector domains, but this field is not currently parsed by pMMC. Exposing it makes the Python wrapper more consistent with the core configuration structure and with MMCLAB behavior.

Optionally, one could also parse `isextdet` as `py::int_` instead of `py::bool_`, because `mcconfig.isextdet` is an `int` and MMCLAB accepts scalar numeric fields. But semantically it is a flag, and `py::bool_` accepts Python `True`/`False` and numeric truthiness. So it is mostly a matter of whether we want maximum consistency with the C field type

This change should be backward compatible: existing boolean-style uses of `isspecular` and omitted/default `isextdet` behavior are unchanged.