### PR TITLE
Fix detector lookup offset with extra source records

### DIFF
--- a/src/mmc_core.cl
+++ b/src/mmc_core.cl
@@ -607,12 +607,13 @@ __device__ void clearpath(__local float* p, int len) {
 #if defined(MCX_SAVE_DETECTORS) || defined(__NVCC__)
 __device__ uint finddetector(float3* p0, __constant float4* gmed, __constant MCXParam* gcfg) {
     uint i;
+    uint detstart = GPU_PARAM(gcfg, srcpropoffset) + ((uint)GPU_PARAM(gcfg, extrasrclen) << 2);
 
-    for (i = GPU_PARAM(gcfg, maxmedia) + 1 + GPU_PARAM(gcfg, isextdet); i < GPU_PARAM(gcfg, maxmedia) + 1 + GPU_PARAM(gcfg, isextdet) + GPU_PARAM(gcfg, detnum); i++) {
+    for (i = detstart; i < detstart + GPU_PARAM(gcfg, detnum); i++) {
         if ((gmed[i].x - p0[0].x) * (gmed[i].x - p0[0].x) +
                 (gmed[i].y - p0[0].y) * (gmed[i].y - p0[0].y) +
                 (gmed[i].z - p0[0].z) * (gmed[i].z - p0[0].z) < gmed[i].w * gmed[i].w) {
-            return i - GPU_PARAM(gcfg, maxmedia) - GPU_PARAM(gcfg, isextdet);
+            return i - detstart + 1u;
         }
     }
 


### PR DESCRIPTION
## Summary

Fix detector lookup when multi-source extra records are present in constant memory.

When `extrasrclen > 0`, the extra source records are packed after the optical properties and before detector records. The current `finddetector()` loop starts scanning at `maxmedia + 1 + isextdet`, so it can read extra source records as if they were detector records. This corrupts `detp` output for multi-row sources with saved detectors: detected photon counts collapse and packed source IDs become strongly biased toward source slot 1.

This patch starts detector lookup at:

```c
srcpropoffset + extrasrclen * 4
```

and returns detector IDs relative to that detector start.

## Minimal reproducer

```python
import iso2mesh as i2m
import numpy as np
import pmmc

nphoton = 100_000
mua = 0.01

node, _face, elem = i2m.meshabox([0, 0, -30], [60, 60, 0], 8, 6)

xy = np.linspace(20 + 20 / 6, 40 - 20 / 6, 3)
x, y = np.meshgrid(xy, xy, indexing="xy")
pos = np.column_stack([x.ravel(), y.ravel(), np.full(9, -1e-4)])
srcdir = np.tile([0, 0, -1], (9, 1))

lo = node.min(axis=0)
hi = node.max(axis=0)
center = 0.5 * (lo + hi)
radius = 2.5 * np.linalg.norm(hi - lo)

cfg = {
    "nphoton": nphoton,
    "seed": 12345,
    "gpuid": 1,
    "node": node,
    "elem": elem,
    "elemprop": np.ones(elem.shape[0], dtype=np.int32),
    "prop": np.array([[0, 0, 1, 1], [mua, 10, 0.5, 1.5]], dtype=np.float32),
    "srcpos": np.column_stack([pos, np.ones(9)]),
    "srcdir": srcdir,
    "srcid": -1,
    "tstart": 0,
    "tstep": 1e-6,
    "tend": 1e-6,
    "method": "elem",
    "basisorder": 1,
    "outputtype": "fluence",
    "isnormalized": 1,
    "isreflect": 1,
    "issavedet": 1,
    "issaveexit": 1,
    "maxdetphoton": nphoton,
    "detpos": np.array([[center[0], center[1], center[2], radius]]),
    "unitinmm": 1.0,
}

out = pmmc.run(cfg)
detp = np.asarray(out["detp"], dtype=float)

raw = np.rint(detp[0]).astype(np.uint32)
srcids = raw >> np.uint32(16)
vals, counts = np.unique(srcids, return_counts=True)

nmedia = max(0, (detp.shape[0] - 2 - 6) // 2)
ppath = detp[1 + nmedia : 1 + 2 * nmedia].T
escaped = float(np.sum(detp[-1] * np.exp(-mua * ppath[:, 0])) / nphoton)

print("detp shape", detp.shape)
print("packed source ids:", list(zip(vals.tolist(), counts.tolist())))
print("det-derived escaped:", escaped, "absorbed:", 1 - escaped)
```

## Output before this patch

```text
detp shape (10, 5609)
packed source ids: [(1, 5574), (2, 14), (4, 11), (5, 6), (6, 1), (7, 2), (8, 1)]
det-derived escaped: 0.05366440018197436 absorbed: 0.9463355998180256
```

## Output after this patch

```text
detp shape (10, 97120)
packed source ids: [(1, 10899), (2, 10909), (3, 10530), (4, 10988), (5, 10793), (6, 10681), (7, 10854), (8, 10873), (9, 10593)]
det-derived escaped: 0.7776614094666039 absorbed: 0.2223385905333961
```

The fixed output has the expected near-uniform packed source IDs across the 9 source rows and restores the detector-derived energy accounting.
